### PR TITLE
Drop items until max_items is reached

### DIFF
--- a/mover.lua
+++ b/mover.lua
@@ -1001,8 +1001,9 @@ minetest.register_node("basic_machines:mover", {
 									for _, v in pairs(drops.items) do
 										if items_dropped >= max_items then break end
 										if math.random(1, v.rarity or 1) == 1 then
-											node1 = {name = v.items[math.random(1, #v.items)]} -- pick item randomly from list
-											inv:add_item("main", node1.name)
+											for _, item in ipairs(v.items) do -- pick all items from list
+												inv:add_item("main", item)
+											end
 											items_dropped = items_dropped + 1
 										end
 									end

--- a/mover.lua
+++ b/mover.lua
@@ -997,12 +997,13 @@ minetest.register_node("basic_machines:mover", {
 									if max_items == 0 then -- just drop all the items (taking the rarity into consideration)
 										max_items = #drops.items or 0
 									end
-									local i = 0
+									local items_dropped = 0
 									for _, v in pairs(drops.items) do
-										if i >= max_items then break end; i = i + 1
+										if items_dropped >= max_items then break end
 										if math.random(1, v.rarity or 1) == 1 then
 											node1 = {name = v.items[math.random(1, #v.items)]} -- pick item randomly from list
 											inv:add_item("main", node1.name)
+											items_dropped = items_dropped + 1
 										end
 									end
 								else


### PR DESCRIPTION
The original mod uses `>` instead of `>=`, which is probably wrong (will always attempt to drop max_items + 1):

```lua
if i > max_items then break end; i=i+1;
```

https://github.com/ac-minetest/basic_machines/blob/a41eb8423d25a7b855899750dab7522c4b0b4c0d/mover.lua#L773

Instead, I think we should only increase `i` if we actually drop something.
