### PR TITLE
Add support to register grinder recipes in Craft Grid Plus mod.

### DIFF
--- a/grinder.lua
+++ b/grinder.lua
@@ -8,6 +8,7 @@ local machines_minstep = basic_machines.properties.machines_minstep
 local twodigits_float = basic_machines.twodigits_float
 local use_unified_inventory = minetest.global_exists("unified_inventory")
 local use_i3 = minetest.global_exists("i3")
+local use_cg_plus = minetest.global_exists("cg") -- Skaapdev add support for cg_plus
 local use_default = basic_machines.use_default
 -- grinder recipes:
 -- ["in"] = {fuel cost, "out", quantity of material produced, quantity of material required for processing}
@@ -26,6 +27,15 @@ elseif use_i3 then
 		description = F(S("Grinding")),
 		icon = "basic_machines_grinder.png"
 	})
+elseif use_cg_plus then -- Skaapdev add support for cg_plus
+    cg.register_craft_type("basic_machines_grinding", {
+        description = F(cg.S("Grinding")),
+        inherit_width = true,
+        arrow_icon = "basic_machines_grinder.png",
+        get_grid_size = function(craft)
+            return {x = 1, y = 1}
+        end,
+    }) -- skaapdev end
 end
 
 local function register_recipe(name, def)
@@ -58,6 +68,8 @@ local function register_recipe(name, def)
 					result = def[2] .. " " .. def[3],
 					items = {name .. " " .. def[4]}
 				})
+			elseif use_cg_plus then -- Skaapdev add support for cg_plus
+			    cg.register_craft("basic_machines_grinding", def[2] .. " " .. def[3], name) -- skaapdev end
 			end
 		end
 	end

--- a/mover_dig_mode.lua
+++ b/mover_dig_mode.lua
@@ -22,7 +22,7 @@ local math_min = math.min
 
 local function is_valid_soil(pos)
     -- skaapdev add support to validate node under seed.
-    local valid_seed_soils = { "farming:soil_wet", "default:dirt", }
+    local valid_seed_soils = { "farming:soil_wet", "farming:soil", "default:dirt", "x_farming:obsidian_soil", "x_farming:obsidian_soil_wet", }
     local pos_under = { x=pos.x, y=pos.y-1, z=pos.z}
     local pos_under_name = minetest.get_node(pos_under).name
     local is_valid_soil = false

--- a/mover_dig_mode.lua
+++ b/mover_dig_mode.lua
@@ -20,6 +20,22 @@ local use_farming = minetest.global_exists("farming")
 local use_x_farming = minetest.global_exists("x_farming")
 local math_min = math.min
 
+local function is_valid_soil(pos)
+    -- skaapdev add support to validate node under seed.
+    local valid_seed_soils = { "farming:soil_wet", "default:dirt", }
+    local pos_under = { x=pos.x, y=pos.y-1, z=pos.z}
+    local pos_under_name = minetest.get_node(pos_under).name
+    local is_valid_soil = false
+    for _, soil in ipairs(valid_seed_soils) do
+        if pos_under_name == soil then
+            is_valid_soil = true
+            break
+        end
+    end
+    --print("MOVER is_valid_soil:" .. dump(is_valid_soil) .. " | pos_under_name:" .. dump(pos_under_name))
+    return is_valid_soil
+end
+
 -- minetest drop code emulation, other idea: minetest.get_node_drops
 local function add_node_drops(node_name, pos, node, filter, node_def, param2)
 	local def = node_def or minetest.registered_nodes[node_name]
@@ -176,6 +192,7 @@ local function dig(pos, meta, owner, prefer, pos1, node1, node1_name, source_che
 			end
 
 			if seed_planting then
+				if not is_valid_soil(pos2) then return end -- skaapdev only plant seeds on valid soil.
 				if third_upgradetype then
 					local length_pos2 = #pos2
 


### PR DESCRIPTION
Adds support to register grinder recipes in Craft Grid Plus mod.
It relies  on my fork of cg plus here: 
https://github.com/Skaapdev/cg_plus/commit/a12463ee5250778b1e2d9078db77f050f56f7e12
( I am still to make PR for cg plus, upstream but project may be abandoned if I look at last activity. ) 

![screenshot_20240404_160922](https://github.com/waxtatect/basic_machines/assets/52762341/82de0ac5-403b-48a8-a980-c7bcf9bc7c9c)

Apologies, I realise only after my previous PR to basic_machines that I should have a branch per feature/bugfix so you can just pick what you want. 

Future PR's should be cleaner.  I have quite a few in the making.

Thanks!