### PR TITLE
QOL - Marker not impede player.

### DIFF
--- a/mark.lua
+++ b/mark.lua
@@ -46,6 +46,8 @@ for _, n in ipairs({"1", "11", "2", "N", "A"}) do
 				texturen, texturen, texturen},
 			glow = 11,
 			static_save = false,
+			physical = false,
+			pointable = false,
 			shaded = false
 		},
 		on_deactivate = function(self)


### PR DESCRIPTION
If player cannot punch marker, they can go on to interact with the node instead of having to wait or punch the marker.